### PR TITLE
Add table helper

### DIFF
--- a/openbb_ai/__init__.py
+++ b/openbb_ai/__init__.py
@@ -4,6 +4,7 @@ from .helpers import cite as cite
 from .helpers import get_widget_data as get_widget_data
 from .helpers import message_chunk as message_chunk
 from .helpers import reasoning_step as reasoning_step
+from .helpers import table as table
 from .models import QueryRequest as QueryRequest
 from .models import Widget as Widget
 from .models import WidgetRequest as WidgetRequest

--- a/openbb_ai/helpers.py
+++ b/openbb_ai/helpers.py
@@ -180,6 +180,57 @@ def citations(citations: list[Citation]) -> CitationCollectionSSE:
     return CitationCollectionSSE(data=CitationCollection(citations=citations))
 
 
+def table(
+    data: list[dict],
+    name: str | None = None,
+    description: str | None = None,
+) -> MessageArtifactSSE:
+    """Create a table message artifact SSE.
+
+    This function constructs a table artifact, which can be `yield`ed to the
+    client to display a table as streamed in-line agent output in OpenBB
+    Workspace.
+
+    Parameters
+    ----------
+    data: list[dict]
+        The data to be visualized in the table. Each dictionary represents a
+        row of the table, where keys represent the "columns" of the data.
+    name: str | None
+        The name of the table. Optional, but recommended.
+    description: str | None
+        A description of the table. Optional, but recommended.
+
+    Examples
+    --------
+    >>> # Create a table
+    >>> table(
+    ...     data=[
+    ...         {"x": 1, "y": 2, "z": 3},
+    ...         {"x": 2, "y": 3, "z": 4},
+    ...         {"x": 3, "y": 4, "z": 5},
+    ...         {"x": 4, "y": 5, "z": 6},
+    ...     ],
+    ...     name="My Table",
+    ...     description="This is a table of the data",
+    ... )
+
+    Returns
+    -------
+    MessageArtifactSSE
+        The table artifact to be sent to the client.
+    """
+
+    return MessageArtifactSSE(
+        data=ClientArtifact(
+            type="table",
+            name=name or "Table",
+            description=description or "A table of data",
+            content=data,
+        )
+    )
+
+
 def chart(
     type: Literal["line", "bar", "scatter", "pie", "donut"],
     data: list[dict],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbb-ai"
-version = "1.3.0"
+version = "1.4.0"
 description = "An SDK for building agents compatible with OpenBB Workspace"
 authors = [
     {name = "Michael Struwig",email = "michael.struwig@openbb.finance"}

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,4 @@
-from openbb_ai.helpers import chart
+from openbb_ai.helpers import chart, table
 from openbb_ai.models import ClientArtifact, MessageArtifactSSE
 
 
@@ -110,3 +110,22 @@ def test_chart_donut():
     assert result.data.chart_params.calloutLabelKey == "y"
     assert result.data.name == "My Donut Chart"
     assert result.data.description == "This is a donut chart of the data"
+
+
+def test_table():
+    result = table(
+        data=[
+            {"x": 1, "y": 2, "z": 3},
+            {"x": 2, "y": 3, "z": 4},
+            {"x": 3, "y": 4, "z": 5},
+            {"x": 4, "y": 5, "z": 6},
+        ],
+        name="My Table",
+        description="This is a table of the data",
+    )
+
+    assert isinstance(result, MessageArtifactSSE)
+    assert isinstance(result.data, ClientArtifact)
+    assert result.data.type == "table"
+    assert result.data.name == "My Table"
+    assert result.data.description == "This is a table of the data"


### PR DESCRIPTION
Add a helper , `table`, that makes it easy for a developer to return a table artifact to OpenBB Workspace from the agent's output.