### PR TITLE
Propagate the py.typed marker to the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.poetry]
+include = ["py.typed"]
+
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.15.0"
 ruff = "^0.11.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,10 @@ name = "openbb-ai"
 version = "1.6.2"
 description = "An SDK for building agents compatible with OpenBB Workspace"
 authors = [
-    {name = "Michael Struwig",email = "michael.struwig@openbb.finance"}
+    { name = "OpenBB Team", email = "hello@openbb.finance" },
+    { name = "Michael Struwig", email = "michael.struwig@openbb.finance" },
+    { name = "Diogo Sousa", email = "diogo.sousa@openbb.finance" },
+    { name = "Theodore Aptekarev", email = "theodore.aptekarev@openbb.finance" },
 ]
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
The [previous pull request](https://github.com/OpenBB-finance/openbb-ai/pull/15) that introduced the `py.typed` marker to satisfy mypy did not correctly propagate it into the package wheel. This results in mypy still complaining if the package is installed from pypi.

This PR adds poetry config to include the marker into the wheel.

