### PR TITLE
Change workspace_options to keyed object values

### DIFF
--- a/openbb_ai/models.py
+++ b/openbb_ai/models.py
@@ -774,9 +774,9 @@ class QueryRequest(BaseModel):
         default=None,
         description="Context of the workspace, with data about current state of the workspace.",  # noqa: E501
     )
-    workspace_options: list[str] | None = Field(
-        default=[],
-        description="A list of options to modify the behavior of the query. ",
+    workspace_options: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Workspace option values keyed by option id.",
     )
     tools: list[AgentTool] | None = Field(
         default=None,


### PR DESCRIPTION
## Summary

Changes the OpenBB AI SDK request model so `QueryRequest.workspace_options` is a dictionary keyed by option id instead of a list of strings.

## What changed

- Replaces `workspace_options: list[str] | None` with `workspace_options: dict[str, Any]`.
- Changes the default from a mutable list default to `default_factory=dict`.
- Documents the field as workspace option values keyed by option id.

## Compatibility

This is a breaking request model change for code that expects `workspace_options` to be a list of enabled flags or `key=value` strings. This PR does not add list normalization or a deprecation path in the SDK model.

Consumers should send and read `workspace_options` as an object, for example:

```json
{
  "web-search": false,
  "model": "gpt-4o"
}
```
