### PR TITLE
Remove summarization protocol version and source hash from schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,19 +157,12 @@ The Workspace persists it as a summary message at the compaction boundary and
 includes it in subsequent requests, so the agent can prompt the model with the
 summary instead of re-reading (or re-summarizing) the covered messages.
 
-Validate a received summary by recomputing the hash of the covered messages
-with `conversation_source_hash` and comparing it to the summary's
-`source_hash`; on mismatch the summary is stale and should be regenerated.
-
 ```python
 from openbb_ai.helpers import conversation_summary
-from openbb_ai.models import conversation_source_hash
 
-covered = messages[: boundary_index + 1]
 yield conversation_summary(
     content="Summary of the earlier conversation...",
-    covered_through_message_id=covered[-1].message_id,
-    source_hash=conversation_source_hash(covered),
+    covered_through_message_id=messages[boundary_index].message_id,
 ).model_dump()
 ```
 

--- a/openbb_ai/__init__.py
+++ b/openbb_ai/__init__.py
@@ -11,4 +11,3 @@ from .models import LlmClientSummaryMessage as LlmClientSummaryMessage
 from .models import QueryRequest as QueryRequest
 from .models import Widget as Widget
 from .models import WidgetRequest as WidgetRequest
-from .models import conversation_source_hash as conversation_source_hash

--- a/openbb_ai/helpers.py
+++ b/openbb_ai/helpers.py
@@ -110,7 +110,6 @@ def prompt_suggestions(suggestions: list[str]) -> PromptSuggestionsSSE:
 def conversation_summary(
     content: str,
     covered_through_message_id: str,
-    source_hash: str,
 ) -> ConversationSummarySSE:
     """Create a conversation summary SSE.
 
@@ -124,9 +123,6 @@ def conversation_summary(
         The summary text of the covered messages.
     covered_through_message_id: str
         The message_id of the last message covered by this summary.
-    source_hash: str
-        Hash of the canonical projection of the covered non-summary messages
-        (see `conversation_source_hash`).
     Returns
     -------
     ConversationSummarySSE
@@ -136,7 +132,6 @@ def conversation_summary(
         data=ConversationSummarySSEData(
             content=content,
             covered_through_message_id=covered_through_message_id,
-            source_hash=source_hash,
         )
     )
 

--- a/openbb_ai/helpers.py
+++ b/openbb_ai/helpers.py
@@ -111,7 +111,6 @@ def conversation_summary(
     content: str,
     covered_through_message_id: str,
     source_hash: str,
-    version: int = 1,
 ) -> ConversationSummarySSE:
     """Create a conversation summary SSE.
 
@@ -128,10 +127,6 @@ def conversation_summary(
     source_hash: str
         Hash of the canonical projection of the covered non-summary messages
         (see `conversation_source_hash`).
-    version: int
-        Schema version of the summary message.
-        Default is 1.
-
     Returns
     -------
     ConversationSummarySSE
@@ -142,7 +137,6 @@ def conversation_summary(
             content=content,
             covered_through_message_id=covered_through_message_id,
             source_hash=source_hash,
-            version=version,
         )
     )
 

--- a/openbb_ai/models.py
+++ b/openbb_ai/models.py
@@ -558,9 +558,6 @@ class LlmClientSummaryMessage(BaseModel):
             "messages, used to detect stale summaries after history edits."
         )
     )
-    version: int = Field(
-        default=1, description="Schema version of the summary message."
-    )
 
 
 class SingleFileReference(BaseModel):
@@ -1058,9 +1055,6 @@ class ConversationSummarySSEData(BaseModel):
             "Hash of the canonical projection of the covered non-summary "
             "messages (see conversation_source_hash)."
         )
-    )
-    version: int = Field(
-        default=1, description="Schema version of the summary message."
     )
 
 

--- a/openbb_ai/models.py
+++ b/openbb_ai/models.py
@@ -539,9 +539,7 @@ class LlmClientSummaryMessage(BaseModel):
     persisted by the client at the compaction boundary.
 
     Agents should use the summary in place of the covered messages when
-    constructing the model prompt, after validating ``source_hash`` against
-    the canonical projection of the covered messages (see
-    ``conversation_source_hash``).
+    constructing the model prompt.
     """
 
     role: Literal["summary"] = "summary"
@@ -550,12 +548,6 @@ class LlmClientSummaryMessage(BaseModel):
         description=(
             "The message_id of the last message covered by this summary. "
             "All non-summary messages up to and including it are covered."
-        )
-    )
-    source_hash: str = Field(
-        description=(
-            "Hash of the canonical projection of the covered non-summary "
-            "messages, used to detect stale summaries after history edits."
         )
     )
 
@@ -652,53 +644,6 @@ class RawContext(BaseModel):
         default=None,
         description="Additional widget metadata (eg. the selected ticker, etc)",
     )
-
-
-LlmMessage = (
-    LlmClientFunctionCallResultMessage | LlmClientMessage | LlmClientSummaryMessage
-)
-
-
-def conversation_source_hash(messages: "list[LlmMessage]") -> str:
-    """Hash the canonical projection of a sequence of conversation messages.
-
-    Used to validate that a ``LlmClientSummaryMessage`` still covers the
-    messages it was generated from. The projection deliberately excludes
-    volatile fields that change between requests without changing the
-    conversation itself: tool-result ``data`` payloads (file URLs are
-    renewed by clients) and ``extra_state`` (mutated on every round trip).
-    Summary messages never feed the hash.
-    """
-    hasher = xxhash.xxh64()
-    for message in messages:
-        if isinstance(message, LlmClientSummaryMessage):
-            continue
-        if isinstance(message, LlmClientFunctionCallResultMessage):
-            body: dict[str, Any] = {
-                "role": "tool",
-                "function": message.function,
-                "input_arguments": message.input_arguments,
-                "message_id": message.message_id,
-            }
-        else:
-            content: Any = message.content
-            if isinstance(content, LlmClientFunctionCall):
-                content = {
-                    "function": content.function,
-                    "input_arguments": content.input_arguments,
-                }
-            body = {
-                "role": message.role.value,
-                "content": content,
-                "message_id": message.message_id,
-            }
-        hasher.update(
-            json.dumps(body, sort_keys=True, default=str, ensure_ascii=False).encode(
-                "utf-8"
-            )
-        )
-        hasher.update(b"\x1e")
-    return hasher.hexdigest()
 
 
 class DataSourceRequestPayload(BaseModel):
@@ -1049,12 +994,6 @@ class ConversationSummarySSEData(BaseModel):
     content: str = Field(description="The summary text of the covered messages.")
     covered_through_message_id: str = Field(
         description="The message_id of the last message covered by this summary."
-    )
-    source_hash: str = Field(
-        description=(
-            "Hash of the canonical projection of the covered non-summary "
-            "messages (see conversation_source_hash)."
-        )
     )
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -51,7 +51,6 @@ def test_conversation_summary():
     assert result.data.content == "The user analyzed AAPL revenue trends."
     assert result.data.covered_through_message_id == "msg-42"
     assert result.data.source_hash == "abc123"
-    assert result.data.version == 1
 
     dumped = result.model_dump()
     assert dumped["event"] == "copilotConversationSummary"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -43,15 +43,12 @@ def test_conversation_summary():
     result = conversation_summary(
         content="The user analyzed AAPL revenue trends.",
         covered_through_message_id="msg-42",
-        source_hash="abc123",
     )
 
     assert isinstance(result, ConversationSummarySSE)
     assert result.event == "copilotConversationSummary"
     assert result.data.content == "The user analyzed AAPL revenue trends."
     assert result.data.covered_through_message_id == "msg-42"
-    assert result.data.source_hash == "abc123"
-
     dumped = result.model_dump()
     assert dumped["event"] == "copilotConversationSummary"
     assert '"covered_through_message_id":"msg-42"' in dumped["data"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,45 +4,12 @@ from openbb_ai.models import (
     AgentFeatureOption,
     Citation,
     CitationHighlightBoundingBox,
-    DataContent,
-    LlmClientFunctionCallResultMessage,
     LlmClientMessage,
     LlmClientSummaryMessage,
     QueryRequest,
-    SingleDataContent,
     SourceInfo,
     WorkspaceAgent,
-    conversation_source_hash,
 )
-
-
-def _human(content: str, message_id: str | None = None) -> LlmClientMessage:
-    return LlmClientMessage(role="human", content=content, message_id=message_id)
-
-
-def _ai(content: str, message_id: str | None = None) -> LlmClientMessage:
-    return LlmClientMessage(role="ai", content=content, message_id=message_id)
-
-
-def _tool_result(
-    function: str = "get_widget_data",
-    message_id: str | None = None,
-) -> LlmClientFunctionCallResultMessage:
-    return LlmClientFunctionCallResultMessage(
-        function=function,
-        input_arguments={"data_sources": []},
-        data=[DataContent(items=[SingleDataContent(content="some data")])],
-        extra_state={"round_trip": 1},
-        message_id=message_id,
-    )
-
-
-def _summary(covered_through: str = "m1") -> LlmClientSummaryMessage:
-    return LlmClientSummaryMessage(
-        content="Earlier turns summarized.",
-        covered_through_message_id=covered_through,
-        source_hash="deadbeef",
-    )
 
 
 def test_query_request_parses_summary_message():
@@ -54,7 +21,6 @@ def test_query_request_parses_summary_message():
                     "role": "summary",
                     "content": "Earlier turns summarized.",
                     "covered_through_message_id": "m1",
-                    "source_hash": "deadbeef",
                 },
                 {"role": "human", "content": "next question"},
             ]
@@ -65,7 +31,6 @@ def test_query_request_parses_summary_message():
     assert request.messages[0].message_id == "m1"
     assert isinstance(request.messages[1], LlmClientSummaryMessage)
     assert request.messages[1].covered_through_message_id == "m1"
-    assert request.messages[1].source_hash == "deadbeef"
     assert isinstance(request.messages[2], LlmClientMessage)
     assert request.messages[2].message_id is None
 
@@ -75,45 +40,6 @@ def test_message_id_is_optional_and_round_trips():
     assert message.message_id is None
     dumped = LlmClientMessage(role="ai", content="hi", message_id="m9").model_dump()
     assert dumped["message_id"] == "m9"
-
-
-def test_conversation_source_hash_is_deterministic():
-    messages = [_human("q1", "m1"), _ai("a1", "m2"), _tool_result(message_id="m3")]
-    identical = [_human("q1", "m1"), _ai("a1", "m2"), _tool_result(message_id="m3")]
-    assert conversation_source_hash(messages) == conversation_source_hash(identical)
-
-
-def test_conversation_source_hash_ignores_volatile_fields():
-    messages = [_human("q1", "m1"), _tool_result(message_id="m2")]
-    reference = conversation_source_hash(messages)
-
-    mutated = [_human("q1", "m1"), _tool_result(message_id="m2")]
-    mutated[1].data = [DataContent(items=[SingleDataContent(content="renewed URL")])]
-    mutated[1].extra_state = {"round_trip": 2, "deferred_function_calls": ["x"]}
-    assert conversation_source_hash(mutated) == reference
-
-
-def test_conversation_source_hash_detects_edits():
-    messages = [_human("q1", "m1"), _ai("a1", "m2")]
-    reference = conversation_source_hash(messages)
-
-    edited_content = [_human("q1 edited", "m1"), _ai("a1", "m2")]
-    assert conversation_source_hash(edited_content) != reference
-
-    reordered = [_ai("a1", "m2"), _human("q1", "m1")]
-    assert conversation_source_hash(reordered) != reference
-
-    different_id = [_human("q1", "m1"), _ai("a1", "m99")]
-    assert conversation_source_hash(different_id) != reference
-
-    removed = [_human("q1", "m1")]
-    assert conversation_source_hash(removed) != reference
-
-
-def test_conversation_source_hash_excludes_summaries():
-    messages = [_human("q1", "m1"), _ai("a1", "m2")]
-    with_summary = [_human("q1", "m1"), _summary("m1"), _ai("a1", "m2")]
-    assert conversation_source_hash(with_summary) == conversation_source_hash(messages)
 
 
 def test_workspace_agent_supports_feature_option_metadata():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -55,7 +55,6 @@ def test_query_request_parses_summary_message():
                     "content": "Earlier turns summarized.",
                     "covered_through_message_id": "m1",
                     "source_hash": "deadbeef",
-                    "version": 1,
                 },
                 {"role": "human", "content": "next question"},
             ]
@@ -67,7 +66,6 @@ def test_query_request_parses_summary_message():
     assert isinstance(request.messages[1], LlmClientSummaryMessage)
     assert request.messages[1].covered_through_message_id == "m1"
     assert request.messages[1].source_hash == "deadbeef"
-    assert request.messages[1].version == 1
     assert isinstance(request.messages[2], LlmClientMessage)
     assert request.messages[2].message_id is None
 


### PR DESCRIPTION
Simplifies the conversation summary protocol by removing the schema version, source hash, and public hashing helper. Summary content and the last covered message ID are sufficient for the supported conversation flow, where intermediate messages are not edited, deleted, or reordered.

This reduces the public model and helper API without changing how agents emit or receive persisted summaries.