### PR TITLE
Add save_skill client function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ from openbb_ai import (
 
 app = FastAPI()
 
+
 @app.get("/agents.json")
 async def agents_json():
     return JSONResponse(
@@ -60,7 +61,9 @@ async def agents_json():
                 "name": "My Agent",
                 "description": "This is my agent",
                 "image": f"{AGENT_BASE_URL}/my-agent/logo.png",
-                "endpoints": {"query": f"{AGENT_BASE_URL}/query"},  # must match the query endpoint below
+                "endpoints": {
+                    "query": f"{AGENT_BASE_URL}/query"
+                },  # must match the query endpoint below
                 "features": {
                     "streaming": True,  # must be True
                     "widget-dashboard-select": True,  # Enable access to priority widgets
@@ -69,6 +72,7 @@ async def agents_json():
             }
         }
     )
+
 
 @app.get("/query")
 async def stream(request: QueryRequest):

--- a/openbb_ai/models.py
+++ b/openbb_ai/models.py
@@ -908,6 +908,7 @@ class FunctionCallSSEData(BaseModel):
         "execute_agent_tool",
         "manage_navigation_bar",
         "get_skill_content",
+        "save_skill",
     ]
     input_arguments: dict
     extra_state: dict | None = Field(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbb-ai"
-version = "2.1.0"
+version = "2.2.0"
 description = "An SDK for building agents compatible with OpenBB Workspace"
 authors = [
     { name = "OpenBB Team", email = "hello@openbb.finance" },


### PR DESCRIPTION
> **Stacked PR:** based on #64 (repo hygiene needed for green CI). Merge that first — GitHub retargets this PR automatically and the diff here contains only the feature.

Part of the cross-repo **"save this as a skill"** feature: users can ask the copilot to save the current conversation's workflow as a reusable skill in their Workspace skill library.

## What this PR does

- Adds `"save_skill"` to the closed `FunctionCallSSEData.function` Literal in `openbb_ai/models.py`, allowing agents to emit a `copilotFunctionCall` SSE that asks the Workspace client to save a skill. This follows the exact precedent of `get_skill_content` (#52).
- Bumps the package version to **2.2.0**.

## Protocol flow enabled by this change

1. The agent (openbb-ada) yields `FunctionCallSSE(function="save_skill", input_arguments={"name", "instructions"})` and closes the stream.
2. The Workspace frontend generates the skill from the conversation, saves it, and re-POSTs `/query` with an `LlmClientFunctionCallResultMessage` carrying a `ClientCommandResult` (`{"skill": {"slug", "description"}}` on success).
3. The agent confirms the save to the user.

## ⚠️ Version note

PR #61 (durable conversation summaries) also bumps to 2.2.0. Whichever of the two merges second must bump to 2.3.0 before release.

## Companion PRs — review/test together

This PR only extends the protocol; the behavior lives in the companion PRs and needs all three to test end-to-end:

- openbb-ada: https://github.com/OpenBB-finance/openbb-ada/pull/643
- terminalpro: https://github.com/OpenBB-finance/terminalpro/pull/2106

**Release ordering:** merge + publish this package to PyPI first (ada's `^2.1.0` caret accepts 2.2.0, but ada CI/Docker installs from PyPI, so the ada PR's new Literal value fails validation until 2.2.0 is published) → then openbb-ada → terminalpro can go before or alongside ada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KocxNUyBQT8K8qTduX7Gyu
