### PR TITLE
Format README code blocks for ruff 0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ from openbb_ai import (
 
 app = FastAPI()
 
+
 @app.get("/agents.json")
 async def agents_json():
     return JSONResponse(
@@ -60,7 +61,9 @@ async def agents_json():
                 "name": "My Agent",
                 "description": "This is my agent",
                 "image": f"{AGENT_BASE_URL}/my-agent/logo.png",
-                "endpoints": {"query": f"{AGENT_BASE_URL}/query"},  # must match the query endpoint below
+                "endpoints": {
+                    "query": f"{AGENT_BASE_URL}/query"
+                },  # must match the query endpoint below
                 "features": {
                     "streaming": True,  # must be True
                     "widget-dashboard-select": True,  # Enable access to priority widgets
@@ -69,6 +72,7 @@ async def agents_json():
             }
         }
     )
+
 
 @app.get("/query")
 async def stream(request: QueryRequest):


### PR DESCRIPTION
Repo hygiene, no behavior change. CI installs ruff unpinned, and ruff 0.16 started formatting Python code blocks inside Markdown files — since the lint workflow only runs on PRs, main drifted and every new PR inherits the failure. This formats the README code blocks so lint is green again.

Split out of https://github.com/OpenBB-finance/openbb-ai/pull/63, which is stacked on this branch — merge this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KocxNUyBQT8K8qTduX7Gyu